### PR TITLE
Feat/real endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,18 @@ name = "simbld-auth"
 version = "0.1.0"
 edition = "2021"
 
+# Multiple binaries
 [[bin]]
-name = "simbld_auth"
+name = "main"
 path = "src/main.rs"
+
+[[bin]]
+name = "simple_mock"
+path = "src/bin/simple_mock.rs"
+
+[[bin]]
+name = "mock_server"
+path = "src/bin/mock_server.rs"
 
 [dependencies]
 actix-web = { version = "4.11.0", features = ["cookies"] }

--- a/ROUTES.md
+++ b/ROUTES.md
@@ -44,13 +44,13 @@ curl http://localhost:3000/health/detailed
 # 2. Test auth (register)
 
 curl -X POST http://localhost:3000/api/v1/auth/register \
--H "Content-Type: application/json" \
+-H "Content-Type: app/json" \
 -d '{"email":"test@example.com","username":"testuser","password":"SecurePass123!"}'
 
 # 3. Test auth (login)
 
 curl -X POST http://localhost:3000/api/v1/auth/login \
--H "Content-Type: application/json" \
+-H "Content-Type: app/json" \
 -d '{"email":"test@example.com","password":"SecurePass123!"}'
 
 # 4. Test user management

--- a/ROUTES.md
+++ b/ROUTES.md
@@ -1,16 +1,16 @@
-***Routes qui NÉCESSITENT une connexion :***
+***Routes that REQUIRE authentication:***
 
-- **GET /api/v1/protected** ← Profil basique de l'utilisateur
-- **GET /api/v1/protected/profile** ← Profil détaillé
-- **PUT /api/v1/protected/settings** ← Modifier ses paramètres
-- **GET /api/v1/protected/orders** ← Voir ses commandes
-- **POST /api/v1/protected/logout** ← Se déconnecter
+- **GET /api/v1/protected** ← Basic user profile
+- **GET /api/v1/protected/profile** ← Detailed profile
+- **PUT /api/v1/protected/settings** ← Modify settings
+- **GET /api/v1/protected/orders** ← View orders
+- **POST /api/v1/protected/logout** ← Logout
 
-***Routes PUBLIQUES :***
+***PUBLIC Routes:***
 
-- **POST /api/v1/auth/register** ← Inscription
-- **POST /api/v1/auth/login** ← Connexion
-- **GET /api/v1/health** ← Status de l'API
+- **POST /api/v1/auth/register** ← Registration
+- **POST /api/v1/auth/login** ← Login
+- **GET /api/v1/health** ← API Status
 
 ---
 
@@ -26,13 +26,33 @@
 
 - **↓**
 -
-- **[Vérifie le token avec AuthService]**
+- **[Verify token with AuthService]**
 
 - **↓**
 -
-- **✅ Token valide → AuthenticatedUser** = *protected_route()*
-- **🛡️ Response avec données utilisateur**
+- **✅ Valid token → AuthenticatedUser** = *protected_route()*
+- **🛡️ Response with user data**
 
 
-- **❌ Token invalide 401 Error** = *HttpResponse::Unauthorized*
+- **❌ Invalid token 401 Error** = *HttpResponse::Unauthorized*
 
+# 1. Test basic health routes
+
+curl http://localhost:3000/health
+curl http://localhost:3000/health/detailed
+
+# 2. Test auth (register)
+
+curl -X POST http://localhost:3000/api/v1/auth/register \
+-H "Content-Type: application/json" \
+-d '{"email":"test@example.com","username":"testuser","password":"SecurePass123!"}'
+
+# 3. Test auth (login)
+
+curl -X POST http://localhost:3000/api/v1/auth/login \
+-H "Content-Type: application/json" \
+-d '{"email":"test@example.com","password":"SecurePass123!"}'
+
+# 4. Test user management
+
+curl http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000

--- a/requests.http
+++ b/requests.http
@@ -1,20 +1,35 @@
 ### =============================================================================
-### 🏭 REAL SERVER
+### 🏭 REAL SERVER - OPTIMIZED TEST SUITE
 ### Server: http://localhost:3000 (Real Server with PostgreSQL)
 ### =============================================================================
 
 ### =============================================================================
-### 🏥 HEALTH & SYSTEM
+### 🏥 HEALTH & SYSTEM (Cleaned)
 ### =============================================================================
 
-### Health Check - Real
+### Basic Health Check
 GET http://localhost:3000/health
+
+### Detailed Health Check
+GET http://localhost:3000/health/detailed
+
+### Readiness Probe
+GET http://localhost:3000/health/ready
+
+### Liveness Probe
+GET http://localhost:3000/health/live
+
+### Simple Health with Real DB
+GET http://localhost:3000/simple-health
+
+### DB Connection Test Only
+GET http://localhost:3000/simple-health/db-only
 
 ### =============================================================================
 ### 🔐 AUTHENTICATION
 ### =============================================================================
 
-### Test 2: Register User
+### Register User
 POST http://localhost:3000/api/v1/auth/register
 Content-Type: application/json
 
@@ -26,7 +41,7 @@ Content-Type: application/json
   "lastname": "User"
 }
 
-### Test 3: Login User
+### Login User
 POST http://localhost:3000/api/v1/auth/login
 Content-Type: application/json
 
@@ -39,15 +54,15 @@ Content-Type: application/json
 ### 🔒 PROTECTED ROUTES
 ### =============================================================================
 
-### Test 4: Protected Main Route
+### Protected Main Route
 GET http://localhost:3000/api/v1/protected
 Authorization: mock_access_token_12345
 
-### Test 5: Protected Profile
+### Protected Profile
 GET http://localhost:3000/api/v1/protected/profile
 Authorization: mock_access_token_12345
 
-### Test 6: Protected Settings Update
+### Protected Settings Update
 PUT http://localhost:3000/api/v1/protected/settings
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -58,43 +73,39 @@ Content-Type: application/json
   "language": "fr"
 }
 
-### Test 7: Protected Orders
+### Protected Orders
 GET http://localhost:3000/api/v1/protected/orders
 Authorization: mock_access_token_12345
 
-### Test 8: Logout
+### Logout
 POST http://localhost:3000/api/v1/protected/logout
 Authorization: mock_access_token_12345
 
 ### =============================================================================
-### 👥 USER MANAGEMENT - COLLECTION OPERATIONS
+### 👥 USER MANAGEMENT
 ### =============================================================================
 
-### Test 9: List All Users
+### List All Users
 GET http://localhost:3000/api/v1/users
 Authorization: mock_access_token_12345
 
-### Test 10: User Statistics (Admin)
+### User Statistics (Admin)
 GET http://localhost:3000/api/v1/users/stats
 Authorization: mock_access_token_12345
 
-### Test 11: Find User by Email (Admin)
+### Find User by Email
 GET http://localhost:3000/api/v1/users/by-email?email=test@example.com
 Authorization: mock_access_token_12345
 
-### Test 12: Find User by Username (Admin)
+### Find User by Username
 GET http://localhost:3000/api/v1/users/by-username?username=testuser
 Authorization: mock_access_token_12345
 
-### =============================================================================
-### 👤 USER MANAGEMENT - INDIVIDUAL OPERATIONS
-### =============================================================================
-
-### Test 13: Get User by ID
+### Get User by ID
 GET http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000
 Authorization: mock_access_token_12345
 
-### Test 14: Update User Profile
+### Update User Profile
 PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/profile
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -106,7 +117,7 @@ Content-Type: application/json
   "bio": "Updated user biography"
 }
 
-### Test 15: ⭐ Change Password (THE MAIN ONE!)
+### ⭐ Change Password (MAIN TARGET)
 PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/password
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -116,7 +127,7 @@ Content-Type: application/json
   "new_password": "NouveauMot123!"
 }
 
-### Test 16: Update User Status (Admin)
+### Update User Status (Admin)
 PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/status
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -126,11 +137,11 @@ Content-Type: application/json
   "reason": "Policy violation"
 }
 
-### Test 17: Get User Roles
+### Get User Roles
 GET http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/roles
 Authorization: mock_access_token_12345
 
-### Test 18: Assign Role (Admin)
+### Assign Role (Admin)
 POST http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/roles
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -143,19 +154,19 @@ Content-Type: application/json
 ### 🧪 ERROR TESTING
 ### =============================================================================
 
-### Test 19: Invalid UUID Format
+### Invalid UUID Format
 GET http://localhost:3000/api/v1/users/invalid-uuid-format
 Authorization: mock_access_token_12345
 
-### Test 20: Missing Email Parameter
+### Missing Email Parameter
 GET http://localhost:3000/api/v1/users/by-email
 Authorization: mock_access_token_12345
 
-### Test 21: Missing Username Parameter
+### Missing Username Parameter
 GET http://localhost:3000/api/v1/users/by-username
 Authorization: mock_access_token_12345
 
-### Test 22: Invalid Password Change (Too Short)
+### Password Too Short (Validation Test)
 PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/password
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -165,7 +176,7 @@ Content-Type: application/json
   "new_password": "123"
 }
 
-### Test 23: Missing Password Fields
+### Missing Current Password
 PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/password
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -174,36 +185,36 @@ Content-Type: application/json
   "new_password": "NouveauMot123!"
 }
 
-### Test 24: No Authorization Header
+### No Authorization Header
 GET http://localhost:3000/api/v1/protected
 
-### Test 25: Invalid JSON Format
-POST http://localhost:3000/api/v1/auth/login
-Content-Type: application/json
-
-{
-  "email": "test@example.com",
-  "password": "invalid-json"
-}
-
 ### =============================================================================
-### 🎯 QUICK TESTS - ESSENTIALS
+### 🧪 REAL DATABASE DEBUG
 ### =============================================================================
 
-### Login
-POST http://localhost:3000/api/v1/auth/login
-Content-Type: application/json
-
-{
-  "email": "test@example.com",
-  "password": "SecurePassword123!"
-}
-
-### Protected Route
-GET http://localhost:3000/api/v1/protected
+### Test Real Database Connection
+GET http://localhost:3000/api/v1/debug/db-test
 Authorization: mock_access_token_12345
 
-### Change Password (MAIN TARGET)
+### Check Database Tables
+GET http://localhost:3000/api/v1/debug/db-tables
+Authorization: mock_access_token_12345
+
+### =============================================================================
+### 🎯 ALTERNATIVE USER IDs (for flexibility)
+### =============================================================================
+
+### Alternative Password Change - Simple ID
+PUT http://localhost:3000/api/v1/users/123/password
+Authorization: mock_access_token_12345
+Content-Type: application/json
+
+{
+  "current_password": "MotDePasse123!",
+  "new_password": "NouveauMot123!"
+}
+
+### Alternative Password Change - Mock User ID
 PUT http://localhost:3000/api/v1/users/mock-user-123/password
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -211,167 +222,4 @@ Content-Type: application/json
 {
   "current_password": "MotDePasse123!",
   "new_password": "NouveauMot123!"
-}
-
-### =============================================================================
-### 💡 ALTERNATIVE USER IDs FOR TESTING
-### =============================================================================
-
-### Test with Alternative User ID 1
-GET http://localhost:3000/api/v1/users/mock-user-123
-Authorization: mock_access_token_12345
-
-### Test with Alternative User ID 2
-PUT http://localhost:3000/api/v1/users/test-user-456/password
-Authorization: mock_access_token_12345
-Content-Type: application/json
-
-{
-  "current_password": "MotDePasse123!",
-  "new_password": "NouveauMot123!"
-}
-
-### Test with Alternative User ID 3
-PUT http://localhost:3000/api/v1/users/user123/password
-Authorization: mock_access_token_12345
-Content-Type: application/json
-
-{
-  "current_password": "MotDePasse123!",
-  "new_password": "NouveauMot123!"
-}
-
-### =============================================================================
-### 🔥 STRESS TESTING
-### =============================================================================
-
-### Stress Test: Large Payload
-PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/profile
-Authorization: mock_access_token_12345
-Content-Type: application/json
-
-{
-  "firstname": "VeryLongFirstNameThatExceedsNormalLimits",
-  "lastname": "VeryLongLastNameThatExceedsNormalLimits",
-  "username": "verylongusernamethatexceedsnormallimits",
-  "bio": "This is a long biography that contains a lot of text to test how the system handles large payloads and whether it can process them correctly without any issues or performance degradation",
-  "metadata": {
-    "preferences": {
-      "theme": "dark",
-      "language": "fr",
-      "notifications": {
-        "email": true,
-        "push": false,
-        "sms": true
-      }
-    }
-  }
-}
-
-### =============================================================================
-### 📝 NOTES
-### =============================================================================
-# Server URL: http://localhost:3000
-# Default Authorization: mock_access_token_12345
-# Main Test: Change Password (Test 15 & Quick Test 4)
-#
-# To run all tests:
-# 1. Start server: cargo run
-# 2. Run tests in order: Health -> Auth -> Protected -> Users
-# 3. Focus on Test 15 for password change functionality
-#
-# Expected responses should be JSON with appropriate status codes
-### =============================================================================
-### 🗄️ DATABASE CONNECTION TESTING
-### =============================================================================
-
-### Test Real Database Health (from your health.rs)
-GET http://localhost:3000/health/detailed
-Authorization: mock_access_token_12345
-
-### Test Database Readiness
-GET http://localhost:3000/health/ready
-Authorization: mock_access_token_12345
-
-### Test Simple Health
-GET http://localhost:3000/health
-
-### Test Detailed Health (NEW!)
-GET http://localhost:3000/health/detailed
-
-### Test Readiness
-GET http://localhost:3000/health/ready
-
-### Test Liveness
-GET http://localhost:3000/health/live
-
-
-### =============================================================================
-### 🧪 REAL DATABASE OPERATIONS (IF CONNECTED)
-### =============================================================================
-
-### Test Real DB 1: Create Real User (would fail with mock)
-POST http://localhost:3000/api/v1/users/real
-Authorization: mock_access_token_12345
-Content-Type: application/json
-
-{
-  "email": "realuser@example.com",
-  "username": "realuser",
-  "password": "RealPassword123!",
-  "firstname": "Real",
-  "lastname": "User"
-}
-
-### Test Real DB 2: Query Database Directly
-GET http://localhost:3000/api/v1/debug/db-test
-Authorization: mock_access_token_12345
-
-### Test Real DB 3: Check Database Tables
-GET http://localhost:3000/api/v1/debug/db-tables
-Authorization: mock_access_token_12345
-
-### =============================================================================
-### 📊 MOCK VS REAL COMPARISON
-### =============================================================================
-
-### Mock Response (Current)
-GET http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000
-Authorization: mock_access_token_12345
-
-### Real DB Response (Would be different)
-GET http://localhost:3000/api/v1/users/real/550e8400-e29b-41d4-a716-446655440000
-Authorization: mock_access_token_12345
-
-### =============================================================================
-### 🏭 REAL SERVER - READY
-### =============================================================================
-
-### TODO: Register User - Real (when auth module ready)
-POST http://localhost:3000/api/v1/auth/register
-Content-Type: application/json
-
-{
-  "email": "real@example.com",
-  "username": "realuser",
-  "password": "RealPassword123!"
-}
-
-### TODO: Login User - Real (when auth module ready)
-POST http://localhost:3000/api/v1/auth/login
-Content-Type: application/json
-
-{
-  "email": "real@example.com",
-  "password": "RealPassword123!"
-}
-
-### TODO: Change Password - Real (when user module ready)
-PUT http://localhost:3000/api/v1/users/{id}/password
-Authorization: Bearer real_token_here
-Content-Type: application/json
-
-{
-  "current_password": "RealPassword123!",
-  "new_password": "NewRealPassword123!"
 }

--- a/requests.http
+++ b/requests.http
@@ -1,14 +1,14 @@
 ### =============================================================================
-### API MOCK SERVER - COMPLETE TEST SUITE
-### Server: http://localhost:3000
+### 🏭 REAL SERVER
+### Server: http://localhost:3000 (Real Server with PostgreSQL)
 ### =============================================================================
 
 ### =============================================================================
 ### 🏥 HEALTH & SYSTEM
 ### =============================================================================
 
-### Test 1: Health Check
-GET http://localhost:3000/api/v1/health
+### Health Check - Real
+GET http://localhost:3000/health
 
 ### =============================================================================
 ### 🔐 AUTHENTICATION
@@ -190,10 +190,7 @@ Content-Type: application/json
 ### 🎯 QUICK TESTS - ESSENTIALS
 ### =============================================================================
 
-### Quick Test 1: Health Check
-GET http://localhost:3000/api/v1/health
-
-### Quick Test 2: Login
+### Login
 POST http://localhost:3000/api/v1/auth/login
 Content-Type: application/json
 
@@ -202,11 +199,11 @@ Content-Type: application/json
   "password": "SecurePassword123!"
 }
 
-### Quick Test 3: Protected Route
+### Protected Route
 GET http://localhost:3000/api/v1/protected
 Authorization: mock_access_token_12345
 
-### Quick Test 4: ⭐ Change Password (MAIN TARGET)
+### Change Password (MAIN TARGET)
 PUT http://localhost:3000/api/v1/users/mock-user-123/password
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -248,16 +245,7 @@ Content-Type: application/json
 ### 🔥 STRESS TESTING
 ### =============================================================================
 
-### Stress Test 1: Multiple Rapid Requests
-GET http://localhost:3000/api/v1/health
-
-###
-GET http://localhost:3000/api/v1/health
-
-###
-GET http://localhost:3000/api/v1/health
-
-### Stress Test 2: Large Payload
+### Stress Test: Large Payload
 PUT http://localhost:3000/api/v1/users/550e8400-e29b-41d4-a716-446655440000/profile
 Authorization: mock_access_token_12345
 Content-Type: application/json
@@ -356,36 +344,34 @@ GET http://localhost:3000/api/v1/users/real/550e8400-e29b-41d4-a716-446655440000
 Authorization: mock_access_token_12345
 
 ### =============================================================================
-### 🏥 SIMPLE HEALTH CHECKS (avec vraie connexion DB)
+### 🏭 REAL SERVER - READY
 ### =============================================================================
 
-### Test Simple Health - Route principale avec test DB réel
-GET http://localhost:3000/simple-health
+### TODO: Register User - Real (when auth module ready)
+POST http://localhost:3000/api/v1/auth/register
+Content-Type: application/json
 
-### Test Simple Health - DB uniquement
-GET http://localhost:3000/simple-health/db-only
+{
+  "email": "real@example.com",
+  "username": "realuser",
+  "password": "RealPassword123!"
+}
 
-### Test Simple Health avec DATABASE_URL custom
-# @name healthWithCustomDB
-GET http://localhost:3000/simple-health
-# Note: Configure DATABASE_URL avant de lancer le serveur
+### TODO: Login User - Real (when auth module ready)
+POST http://localhost:3000/api/v1/auth/login
+Content-Type: application/json
 
-### Test Simple Health - Vérification des erreurs de connexion
-# Ce test montrera les vraies erreurs de connexion PostgreSQL
-GET http://localhost:3000/simple-health/db-only
+{
+  "email": "real@example.com",
+  "password": "RealPassword123!"
+}
 
-### =============================================================================
-### 🔄 COMPARAISON DES HEALTH CHECKS
-### =============================================================================
+### TODO: Change Password - Real (when user module ready)
+PUT http://localhost:3000/api/v1/users/{id}/password
+Authorization: Bearer real_token_here
+Content-Type: application/json
 
-### Health Check Standard (Mock)
-GET http://localhost:3000/health
-
-### Health Check Détaillé (Mock)
-GET http://localhost:3000/health/detailed
-
-### Simple Health Check (Vraie DB)
-GET http://localhost:3000/simple-health
-
-### Simple Health DB Test (Vraie DB)
-GET http://localhost:3000/simple-health/db-only
+{
+  "current_password": "RealPassword123!",
+  "new_password": "NewRealPassword123!"
+}

--- a/requests_mock.http
+++ b/requests_mock.http
@@ -1,0 +1,80 @@
+### =============================================================================
+### 🔧 MOCK SERVER - TEST SUITE
+### Server: http://localhost:3001 (Mock Server)
+### =============================================================================
+
+### Health Check - Mock
+GET http://localhost:3001/health
+
+### Health Check Detailed - Mock
+GET http://localhost:3001/health/detailed
+
+### Simple Health with Mock DB
+GET http://localhost:3001/simple-health
+
+### Simple Health DB Only - Mock
+GET http://localhost:3001/simple-health/db-only
+
+### =============================================================================
+### 🔐 AUTHENTICATION - MOCK
+### =============================================================================
+
+### Register User - Mock
+POST http://localhost:3001/api/v1/auth/register
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "username": "testuser",
+  "password": "SecurePassword123!"
+}
+
+### Login User - Mock
+POST http://localhost:3001/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "SecurePassword123!"
+}
+
+### =============================================================================
+### 👤 USER MANAGEMENT - MOCK
+### =============================================================================
+
+### ⭐ Change Password - MAIN TARGET (Mock)
+PUT http://localhost:3001/api/v1/users/550e8400-e29b-41d4-a716-446655440000/password
+Content-Type: application/json
+
+{
+  "current_password": "MotDePasse123!",
+  "new_password": "NouveauMot123!"
+}
+
+### Change Password - Short Password Test (Mock)
+PUT http://localhost:3001/api/v1/users/123/password
+Content-Type: application/json
+
+{
+  "current_password": "oldpass123",
+  "new_password": "short"
+}
+
+### Get User by ID - Mock
+GET http://localhost:3001/api/v1/users/550e8400-e29b-41d4-a716-446655440000
+
+### List All Users - Mock
+GET http://localhost:3001/api/v1/users
+
+### User Stats - Mock
+GET http://localhost:3001/api/v1/users/stats
+
+### =============================================================================
+### 🧪 DATABASE DEBUG - MOCK
+### =============================================================================
+
+### DB Test - Mock
+GET http://localhost:3001/api/v1/debug/db-test
+
+### DB Tables - Mock
+GET http://localhost:3001/api/v1/debug/db-tables

--- a/src/auth/mfa/mod.rs
+++ b/src/auth/mfa/mod.rs
@@ -15,7 +15,7 @@ pub mod sms;
 pub mod totp;
 pub mod webauthn;
 
-use crate::auth::dto::MfaType;
+pub use crate::auth::dto::MfaType;
 pub use backup_codes::{BackupCodeError, BackupCodeService};
 pub use totp::{TotpError, TotpService};
 
@@ -260,7 +260,6 @@ impl MfaService {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::mocks::mock_client::MockClient;
     use tokio_postgres::Row;
 

--- a/src/bin/mock_server.rs
+++ b/src/bin/mock_server.rs
@@ -1,0 +1,461 @@
+//! Mock server for testing and development
+//! Uses only simulated responses, no real database
+
+use actix_web::{web, App, HttpResponse, HttpServer};
+use serde_json::json;
+
+/// Mock protected route handler - simulates authenticated endpoints
+async fn mock_protected() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Protected route accessed successfully",
+        "user_id": "mock-user-123",
+        "authenticated": true
+    })))
+}
+
+/// List users endpoint - returns paginated user collection
+async fn mock_users() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "users": [
+            {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "username": "testuser",
+                "email": "test@example.com",
+                "status": "active"
+            }
+        ],
+        "total": 1,
+        "limit": 50,
+        "offset": 0
+    })))
+}
+
+/// Get user by ID endpoint - returns detailed user information
+async fn mock_user_by_id(path: web::Path<String>) -> actix_web::Result<HttpResponse> {
+    let user_id = path.into_inner();
+    Ok(HttpResponse::Ok().json(json!({
+        "id": user_id,
+        "username": "testuser",
+        "email": "test@example.com",
+        "firstname": "Test",
+        "lastname": "User",
+        "display_name": "Test User",
+        "status": "active",
+        "email_verified": true,
+        "mfa_enabled": false,
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "updated_at": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// User authentication endpoint - validates credentials and returns JWT tokens
+async fn mock_login(payload: web::Json<serde_json::Value>) -> actix_web::Result<HttpResponse> {
+    let email = payload.get("email").and_then(|v| v.as_str());
+    let password = payload.get("password").and_then(|v| v.as_str());
+
+    // Basic validation
+    if email.is_none() || password.is_none() {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Invalid credentials",
+            "message": "Email and password are required"
+        })));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "access_token": "mock_access_token_12345",
+        "refresh_token": "mock_refresh_token_67890",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "user": {
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "email": email.unwrap(),
+            "username": "testuser"
+        },
+        "login_timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// User registration endpoint - creates a new user account
+async fn mock_register(payload: web::Json<serde_json::Value>) -> actix_web::Result<HttpResponse> {
+    let email = payload.get("email").and_then(|v| v.as_str());
+    let username = payload.get("username").and_then(|v| v.as_str());
+    let password = payload.get("password").and_then(|v| v.as_str());
+
+    // Validation
+    if email.is_none() || username.is_none() || password.is_none() {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Validation failed",
+            "message": "Email, username, and password are required"
+        })));
+    }
+
+    Ok(HttpResponse::Created().json(json!({
+        "user_id": "550e8400-e29b-41d4-a716-446655440000",
+        "email": email.unwrap(),
+        "username": username.unwrap(),
+        "message": "User registered successfully",
+        "status": "pending_verification",
+        "created_at": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Change user password endpoint - validates and updates user credentials
+async fn mock_change_password(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> actix_web::Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let current_password = payload.get("current_password").and_then(|v| v.as_str());
+    let new_password = payload.get("new_password").and_then(|v| v.as_str());
+
+    // Input validation
+    if current_password.is_none() || new_password.is_none() {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Validation failed",
+            "message": "Both current_password and new_password are required"
+        })));
+    }
+
+    // Password strength validation (mock)
+    if let Some(pwd) = new_password {
+        if pwd.len() < 8 {
+            return Ok(HttpResponse::BadRequest().json(json!({
+                "error": "Validation failed",
+                "message": "The new password must be at least 8 characters long"
+            })));
+        }
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Password changed successfully",
+        "user_id": user_id,
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Health check endpoint - returns server status and metadata
+async fn health_check() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "healthy",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "version": "1.0.0",
+        "message": "API server is running"
+    })))
+}
+
+/// Simple detailed health check - mock version
+async fn simple_detailed_health() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "healthy",
+        "service": "API Mock Server",
+        "version": "1.0.0",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "database": {
+            "status": "mocked",
+            "message": "No real database connected - using mock responses",
+            "postgresql_available": false,
+            "connection_string": "NOT_CONFIGURED",
+            "response_time_ms": null
+        },
+        "system": {
+            "hostname": "localhost",
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "pid": std::process::id(),
+            "cpu_cores": num_cpus::get()
+        },
+        "metrics": {
+            "uptime_seconds": 3600,
+            "total_requests": 42,
+            "active_connections": 1,
+            "avg_response_time_ms": 45.2,
+            "error_rate_percent": 0.1
+        }
+    })))
+}
+
+/// Readiness probe
+async fn readiness_probe() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "ready": true,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "checks": {
+            "server": "healthy",
+            "database": "mocked",
+            "memory": "normal",
+            "disk": "sufficient"
+        }
+    })))
+}
+
+/// Liveness probe
+async fn liveness_probe() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "alive": true,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "pid": std::process::id(),
+        "uptime": 3600
+    })))
+}
+
+/// Update user profile endpoint - modifies user personal information
+async fn mock_update_profile(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> actix_web::Result<HttpResponse> {
+    let user_id = path.into_inner();
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Profile updated successfully",
+        "user_id": user_id,
+        "updated_fields": payload.into_inner(),
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Update user status endpoint - admin-only user account management
+async fn mock_update_status(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> actix_web::Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let status = payload.get("status").and_then(|v| v.as_str()).unwrap_or("active");
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "User status updated successfully",
+        "user_id": user_id,
+        "new_status": status,
+        "updated_by": "admin",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Assign role endpoint - admin-only role management
+async fn mock_assign_role(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> actix_web::Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Role assigned successfully",
+        "user_id": user_id,
+        "role": role,
+        "assigned_by": "admin",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Get user roles endpoint - returns user permission set
+async fn mock_get_user_roles(path: web::Path<String>) -> actix_web::Result<HttpResponse> {
+    let user_id = path.into_inner();
+
+    Ok(HttpResponse::Ok().json(json!({
+        "user_id": user_id,
+        "roles": ["user", "customer"],
+        "permissions": ["read_profile", "update_profile", "create_orders"]
+    })))
+}
+
+/// User statistics endpoint - admin-only analytics data
+async fn mock_user_stats() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "total_users": 1547,
+        "active_users": 1289,
+        "pending_users": 156,
+        "suspended_users": 102,
+        "verified_emails": 1203,
+        "mfa_enabled": 687,
+        "recent_logins": 845,
+        "generated_at": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Find a user by email endpoint - admin-only user lookup
+async fn mock_user_by_email(
+    query: web::Query<serde_json::Value>,
+) -> actix_web::Result<HttpResponse> {
+    let email = query.get("email").and_then(|v| v.as_str()).unwrap_or("unknown");
+
+    if email == "unknown" {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Missing parameter",
+            "message": "Email parameter is required"
+        })));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "username": "testuser",
+        "email": email,
+        "firstname": "Test",
+        "lastname": "User",
+        "status": "active",
+        "found_by": "email"
+    })))
+}
+
+/// Find user by username endpoint - admin-only user lookup
+async fn mock_user_by_username(
+    query: web::Query<serde_json::Value>,
+) -> actix_web::Result<HttpResponse> {
+    let username = query.get("username").and_then(|v| v.as_str()).unwrap_or("unknown");
+
+    if username == "unknown" {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Missing parameter",
+            "message": "Username parameter is required"
+        })));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "username": username,
+        "email": "test@example.com",
+        "firstname": "Test",
+        "lastname": "User",
+        "status": "active",
+        "found_by": "username"
+    })))
+}
+
+/// Mock database connection test - simulates real DB connectivity
+async fn mock_db_test() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "database_status": "mocked",
+        "connection": "simulated",
+        "test_query": "SELECT 1",
+        "result": "success (mock)",
+        "message": "This is a mock response. Real database would return actual connection status.",
+        "postgresql_available": false,
+        "mock_mode": true,
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Mock database tables info - simulates table listing
+async fn mock_db_tables() -> actix_web::Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "tables": [
+            {
+                "name": "users",
+                "rows": 1547,
+                "size": "2.3MB"
+            },
+            {
+                "name": "sessions",
+                "rows": 234,
+                "size": "0.8MB"
+            },
+            {
+                "name": "roles",
+                "rows": 12,
+                "size": "0.1MB"
+            }
+        ],
+        "total_tables": 3,
+        "database_size": "3.2MB",
+        "status": "mocked",
+        "message": "Mock table information. A real database would show actual tables.",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Configure all mock routes
+fn configure_mock_routes(cfg: &mut web::ServiceConfig) {
+    cfg
+        // Health routes with mock mode
+        .service(
+            web::scope("/simple-health")
+                .route("", web::get().to(simple_health_with_db))
+                .route("/db-only", web::get().to(database_test_only)),
+        )
+        .route("/api/v1/health", web::get().to(health_check))
+        .route("/health", web::get().to(health_check))
+        .route("/health/detailed", web::get().to(simple_detailed_health))
+        .route("/health/ready", web::get().to(readiness_probe))
+        .route("/health/live", web::get().to(liveness_probe))
+        // Authentication routes - MOCK
+        .service(
+            web::scope("/api/v1/auth")
+                .route("/login", web::post().to(mock_login))
+                .route("/register", web::post().to(mock_register)),
+        )
+        // Protected routes - MOCK
+        .service(
+            web::scope("/api/v1/protected")
+                .route("", web::get().to(mock_protected))
+                .route("/profile", web::get().to(mock_protected))
+                .route("/settings", web::put().to(mock_protected))
+                .route("/orders", web::get().to(mock_protected))
+                .route("/logout", web::post().to(mock_protected)),
+        )
+        // User management routes - MOCK
+        .service(
+            web::scope("/api/v1/users")
+                .route("", web::get().to(mock_users))
+                .route("/stats", web::get().to(mock_user_stats))
+                .route("/by-email", web::get().to(mock_user_by_email))
+                .route("/by-username", web::get().to(mock_user_by_username))
+                .route("/{id}", web::get().to(mock_user_by_id))
+                .route("/{id}/profile", web::put().to(mock_update_profile))
+                .route("/{id}/password", web::put().to(mock_change_password))
+                .route("/{id}/status", web::put().to(mock_update_status))
+                .route("/{id}/roles", web::post().to(mock_assign_role))
+                .route("/{id}/roles", web::get().to(mock_get_user_roles)),
+        )
+        // Debug routes - MOCK
+        .service(
+            web::scope("/api/v1/debug")
+                .route("/db-test", web::get().to(mock_db_test))
+                .route("/db-tables", web::get().to(mock_db_tables)),
+        );
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    dotenvy::dotenv().ok();
+    env_logger::init();
+
+    // Server startup information
+    println!(" Mock Server started on http://localhost:3001");
+    println!("\n Available endpoints:");
+    println!("┌─ Health & System");
+    println!("│GET/api/v1/health");
+    println!("│GET/health ⭐ WORKING.");
+    println!("│GET/health/detailed ⭐ WORKING.");
+    println!("│GET/health/ready ⭐ WORKING.");
+    println!("│GET/health/live ⭐ WORKING.");
+    println!("├─ Authentication");
+    println!("│POST/api/v1/auth/login");
+    println!("│POST/api/v1/auth/register");
+    println!("├─ Protected Routes");
+    println!("│GET/api/v1/protected");
+    println!("│GET/api/v1/protected/profile");
+    println!("│PUT/api/v1/protected/settings");
+    println!("│GET/api/v1/protected/orders");
+    println!("│POST/api/v1/protected/logout");
+    println!("├─ User Management");
+    println!("│GET/api/v1/users");
+    println!("│GET/api/v1/users/{{id}}");
+    println!("│PUT/api/v1/users/{{id}}/profile");
+    println!("│PUT/api/v1/users/{{id}}/password ⭐ TARGET.");
+    println!("│PUT/api/v1/users/{{id}}/status");
+    println!("│POST/api/v1/users/{{id}}/roles");
+    println!("│GET/api/v1/users/{{id}}/roles");
+    println!("│GET/api/v1/users/stats");
+    println!("│GET/api/v1/users/by-email");
+    println!("│GET/api/v1/users/by-username");
+    println!("└─ Database Debug");
+    println!("GET/api/v1/debug/db-test ⭐ NEW!");
+    println!("GET/api/v1/debug/db-tables ⭐ NEW!");
+    println!("\n All endpoints are mocked for testing purposes");
+    println!("Database: MOCKED - No real PostgreSQL connection");
+    println!("Use debug endpoints to simulate DB connectivity checks");
+
+    HttpServer::new(|| App::new().configure(configure_mock_routes))
+        .bind("127.0.0.1:3001")?
+        .run()
+        .await
+}

--- a/src/bin/mock_server.rs
+++ b/src/bin/mock_server.rs
@@ -1,21 +1,37 @@
 //! Mock server for testing and development
 //! Uses only simulated responses, no real database
 
-use actix_web::{web, App, HttpResponse, HttpServer};
-use serde_json::json;
+use actix_web::{web, App, HttpResponse, HttpServer, Result as ActixResult};
+use serde_json::{json, Value};
+use simbld_auth::{database_test_only, simple_health_with_db};
+
+/// Helper to create a standard JSON response
+fn ok_json(data: Value) -> ActixResult<HttpResponse> {
+    Ok(HttpResponse::Ok().json(data))
+}
+
+/// Helper to create an error response
+fn bad_request_json(data: Value) -> ActixResult<HttpResponse> {
+    Ok(HttpResponse::BadRequest().json(data))
+}
+
+/// Helper
+fn created_json(data: Value) -> ActixResult<HttpResponse> {
+    Ok(HttpResponse::Created().json(data))
+}
 
 /// Mock protected route handler - simulates authenticated endpoints
-async fn mock_protected() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn mock_protected() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "message": "Protected route accessed successfully",
         "user_id": "mock-user-123",
         "authenticated": true
-    })))
+    }))
 }
 
 /// List users endpoint - returns paginated user collection
-async fn mock_users() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn mock_users() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "users": [
             {
                 "id": "550e8400-e29b-41d4-a716-446655440000",
@@ -27,13 +43,13 @@ async fn mock_users() -> actix_web::Result<HttpResponse> {
         "total": 1,
         "limit": 50,
         "offset": 0
-    })))
+    }))
 }
 
 /// Get user by ID endpoint - returns detailed user information
-async fn mock_user_by_id(path: web::Path<String>) -> actix_web::Result<HttpResponse> {
+async fn mock_user_by_id(path: web::Path<String>) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "id": user_id,
         "username": "testuser",
         "email": "test@example.com",
@@ -45,23 +61,23 @@ async fn mock_user_by_id(path: web::Path<String>) -> actix_web::Result<HttpRespo
         "mfa_enabled": false,
         "created_at": chrono::Utc::now().to_rfc3339(),
         "updated_at": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// User authentication endpoint - validates credentials and returns JWT tokens
-async fn mock_login(payload: web::Json<serde_json::Value>) -> actix_web::Result<HttpResponse> {
+async fn mock_login(payload: web::Json<Value>) -> ActixResult<HttpResponse> {
     let email = payload.get("email").and_then(|v| v.as_str());
     let password = payload.get("password").and_then(|v| v.as_str());
 
     // Basic validation
     if email.is_none() || password.is_none() {
-        return Ok(HttpResponse::BadRequest().json(json!({
+        return bad_request_json(json!({
             "error": "Invalid credentials",
             "message": "Email and password are required"
-        })));
+        }));
     }
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "access_token": "mock_access_token_12345",
         "refresh_token": "mock_refresh_token_67890",
         "token_type": "Bearer",
@@ -72,80 +88,80 @@ async fn mock_login(payload: web::Json<serde_json::Value>) -> actix_web::Result<
             "username": "testuser"
         },
         "login_timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// User registration endpoint - creates a new user account
-async fn mock_register(payload: web::Json<serde_json::Value>) -> actix_web::Result<HttpResponse> {
+async fn mock_register(payload: web::Json<Value>) -> ActixResult<HttpResponse> {
     let email = payload.get("email").and_then(|v| v.as_str());
     let username = payload.get("username").and_then(|v| v.as_str());
     let password = payload.get("password").and_then(|v| v.as_str());
 
     // Validation
     if email.is_none() || username.is_none() || password.is_none() {
-        return Ok(HttpResponse::BadRequest().json(json!({
-            "error": "Validation failed",
-            "message": "Email, username, and password are required"
-        })));
+        return bad_request_json(json!({
+            "error": "Invalid credentials",
+            "message": "Email and password are required"
+        }));
     }
 
-    Ok(HttpResponse::Created().json(json!({
+    created_json(json!({
         "user_id": "550e8400-e29b-41d4-a716-446655440000",
         "email": email.unwrap(),
         "username": username.unwrap(),
         "message": "User registered successfully",
         "status": "pending_verification",
         "created_at": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Change user password endpoint - validates and updates user credentials
 async fn mock_change_password(
     path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> actix_web::Result<HttpResponse> {
+    payload: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
     let current_password = payload.get("current_password").and_then(|v| v.as_str());
     let new_password = payload.get("new_password").and_then(|v| v.as_str());
 
     // Input validation
     if current_password.is_none() || new_password.is_none() {
-        return Ok(HttpResponse::BadRequest().json(json!({
+        return bad_request_json(json!({
             "error": "Validation failed",
             "message": "Both current_password and new_password are required"
-        })));
+        }));
     }
 
     // Password strength validation (mock)
     if let Some(pwd) = new_password {
         if pwd.len() < 8 {
-            return Ok(HttpResponse::BadRequest().json(json!({
+            return bad_request_json(json!({
                 "error": "Validation failed",
                 "message": "The new password must be at least 8 characters long"
-            })));
+            }));
         }
     }
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "message": "Password changed successfully",
         "user_id": user_id,
         "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Health check endpoint - returns server status and metadata
-async fn health_check() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn health_check() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "status": "healthy",
         "timestamp": chrono::Utc::now().to_rfc3339(),
         "version": "1.0.0",
         "message": "API server is running"
-    })))
+    }))
 }
 
 /// Simple detailed health check - mock version
-async fn simple_detailed_health() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn simple_detailed_health() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "status": "healthy",
         "service": "API Mock Server",
         "version": "1.0.0",
@@ -171,12 +187,12 @@ async fn simple_detailed_health() -> actix_web::Result<HttpResponse> {
             "avg_response_time_ms": 45.2,
             "error_rate_percent": 0.1
         }
-    })))
+    }))
 }
 
 /// Readiness probe
-async fn readiness_probe() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn readiness_probe() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "ready": true,
         "timestamp": chrono::Utc::now().to_rfc3339(),
         "checks": {
@@ -185,82 +201,82 @@ async fn readiness_probe() -> actix_web::Result<HttpResponse> {
             "memory": "normal",
             "disk": "sufficient"
         }
-    })))
+    }))
 }
 
 /// Liveness probe
-async fn liveness_probe() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn liveness_probe() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "alive": true,
         "timestamp": chrono::Utc::now().to_rfc3339(),
         "pid": std::process::id(),
         "uptime": 3600
-    })))
+    }))
 }
 
 /// Update user profile endpoint - modifies user personal information
 async fn mock_update_profile(
     path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> actix_web::Result<HttpResponse> {
+    payload: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "message": "Profile updated successfully",
         "user_id": user_id,
         "updated_fields": payload.into_inner(),
         "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Update user status endpoint - admin-only user account management
 async fn mock_update_status(
     path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> actix_web::Result<HttpResponse> {
+    payload: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
     let status = payload.get("status").and_then(|v| v.as_str()).unwrap_or("active");
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "message": "User status updated successfully",
         "user_id": user_id,
         "new_status": status,
         "updated_by": "admin",
         "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Assign role endpoint - admin-only role management
 async fn mock_assign_role(
     path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> actix_web::Result<HttpResponse> {
+    payload: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
     let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("user");
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "message": "Role assigned successfully",
         "user_id": user_id,
         "role": role,
         "assigned_by": "admin",
         "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Get user roles endpoint - returns user permission set
-async fn mock_get_user_roles(path: web::Path<String>) -> actix_web::Result<HttpResponse> {
+async fn mock_get_user_roles(path: web::Path<String>) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "user_id": user_id,
         "roles": ["user", "customer"],
         "permissions": ["read_profile", "update_profile", "create_orders"]
-    })))
+    }))
 }
 
 /// User statistics endpoint - admin-only analytics data
-async fn mock_user_stats() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn mock_user_stats() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "total_users": 1547,
         "active_users": 1289,
         "pending_users": 156,
@@ -269,23 +285,21 @@ async fn mock_user_stats() -> actix_web::Result<HttpResponse> {
         "mfa_enabled": 687,
         "recent_logins": 845,
         "generated_at": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Find a user by email endpoint - admin-only user lookup
-async fn mock_user_by_email(
-    query: web::Query<serde_json::Value>,
-) -> actix_web::Result<HttpResponse> {
+async fn mock_user_by_email(query: web::Query<Value>) -> ActixResult<HttpResponse> {
     let email = query.get("email").and_then(|v| v.as_str()).unwrap_or("unknown");
 
     if email == "unknown" {
-        return Ok(HttpResponse::BadRequest().json(json!({
+        return bad_request_json(json!({
             "error": "Missing parameter",
             "message": "Email parameter is required"
-        })));
+        }));
     }
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "id": "550e8400-e29b-41d4-a716-446655440000",
         "username": "testuser",
         "email": email,
@@ -293,23 +307,21 @@ async fn mock_user_by_email(
         "lastname": "User",
         "status": "active",
         "found_by": "email"
-    })))
+    }))
 }
 
 /// Find user by username endpoint - admin-only user lookup
-async fn mock_user_by_username(
-    query: web::Query<serde_json::Value>,
-) -> actix_web::Result<HttpResponse> {
+async fn mock_user_by_username(query: web::Query<Value>) -> ActixResult<HttpResponse> {
     let username = query.get("username").and_then(|v| v.as_str()).unwrap_or("unknown");
 
     if username == "unknown" {
-        return Ok(HttpResponse::BadRequest().json(json!({
+        return bad_request_json(json!({
             "error": "Missing parameter",
             "message": "Username parameter is required"
-        })));
+        }));
     }
 
-    Ok(HttpResponse::Ok().json(json!({
+    ok_json(json!({
         "id": "550e8400-e29b-41d4-a716-446655440000",
         "username": username,
         "email": "test@example.com",
@@ -317,12 +329,12 @@ async fn mock_user_by_username(
         "lastname": "User",
         "status": "active",
         "found_by": "username"
-    })))
+    }))
 }
 
 /// Mock database connection test - simulates real DB connectivity
-async fn mock_db_test() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn mock_db_test() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "database_status": "mocked",
         "connection": "simulated",
         "test_query": "SELECT 1",
@@ -331,12 +343,12 @@ async fn mock_db_test() -> actix_web::Result<HttpResponse> {
         "postgresql_available": false,
         "mock_mode": true,
         "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Mock database tables info - simulates table listing
-async fn mock_db_tables() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
+async fn mock_db_tables() -> ActixResult<HttpResponse> {
+    ok_json(json!({
         "tables": [
             {
                 "name": "users",
@@ -359,7 +371,7 @@ async fn mock_db_tables() -> actix_web::Result<HttpResponse> {
         "status": "mocked",
         "message": "Mock table information. A real database would show actual tables.",
         "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
+    }))
 }
 
 /// Configure all mock routes

--- a/src/bin/simple_mock.rs
+++ b/src/bin/simple_mock.rs
@@ -2,6 +2,8 @@
 
 use actix_web::{web, App, HttpServer};
 
+use simbld_auth::mock_handlers::{health_check, mock_change_password, mock_login, mock_register};
+
 /// Configure routes
 fn configure_simple_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/health", web::get().to(health_check))

--- a/src/bin/simple_mock.rs
+++ b/src/bin/simple_mock.rs
@@ -1,0 +1,34 @@
+//! Simple mock server sans sqlx dependencies
+
+use actix_web::{web, App, HttpServer};
+
+/// Configure routes
+fn configure_simple_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/health", web::get().to(health_check))
+        .service(
+            web::scope("/api/v1/auth")
+                .route("/register", web::post().to(mock_register))
+                .route("/login", web::post().to(mock_login)),
+        )
+        .service(
+            web::scope("/api/v1/users")
+                .route("/{id}/password", web::put().to(mock_change_password)),
+        );
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    println!("🚀 Simple Mock Server started on http://localhost:3001");
+    println!("\n✅ Available endpoints:");
+    println!("GET/health");
+    println!("POST/api/v1/auth/register");
+    println!("POST/api/v1/auth/login");
+    println!("PUT/api/v1/users/{{id}}/password");
+
+    HttpServer::new(|| App::new().configure(configure_simple_routes))
+        .bind("127.0.0.1:3001")?
+        .run()
+        .await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+//! Simbld Authentication Service
+//!
+//! A comprehensive authentication and user management service built with Actix-web and PostgreSQL.
+//! Provides JWT-based authentication, user management, and health monitoring capabilities.
+
+pub mod auth;
+pub mod health;
+pub mod mocks;
+pub mod protected;
+pub mod simple_health;
+pub mod sqlx;
+pub mod types;
+pub mod user;
+pub mod utils;
+
+// Re-export commonly used types and functions
+pub use simple_health::{database_test_only, simple_health_with_db};
+
+// Version information
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const SERVICE_NAME: &str = "simbld-auth";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,12 @@
 pub mod health;
 pub mod mocks;
 pub mod protected;*/
-pub mod simple_health;
-/*pub mod sqlx;
-pub mod types;
-pub mod user;
-pub mod utils;*/
+pub mod mock_handlers;
+pub mod simple_health; // ✅ AJOUTE CETTE LIGNE
+                       /*pub mod sqlx;
+                       pub mod types;
+                       pub mod user;
+                       pub mod utils;*/
 
 // Re-export commonly used types and functions
 pub use simple_health::{database_test_only, simple_health_with_db};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 //! Simbld Authentication Service
 //!
-//! A comprehensive authentication and user management service built with Actix-web and PostgreSQL.
+//! A comprehensive authentication and user management service built with Actix-web and `PostgreSQL`.
 //! Provides JWT-based authentication, user management, and health monitoring capabilities.
 
-pub mod auth;
+/*pub mod auth;
 pub mod health;
 pub mod mocks;
-pub mod protected;
+pub mod protected;*/
 pub mod simple_health;
-pub mod sqlx;
+/*pub mod sqlx;
 pub mod types;
 pub mod user;
-pub mod utils;
+pub mod utils;*/
 
 // Re-export commonly used types and functions
 pub use simple_health::{database_test_only, simple_health_with_db};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,461 +1,55 @@
-//! Minimal HTTP server for testing API routes
-//! Production-ready mock implementation without complex dependencies
+//! Server with `PostgreSQL` database connection
 
 mod simple_health;
-mod sqlx;
 
 use crate::simple_health::{database_test_only, simple_health_with_db};
 use actix_web::{web, App, HttpResponse, HttpServer, Result};
 use serde_json::json;
 
-/// Health check endpoint - returns server status and metadata
+/// Health check endpoint
 async fn health_check() -> Result<HttpResponse> {
     Ok(HttpResponse::Ok().json(json!({
         "status": "healthy",
         "timestamp": chrono::Utc::now().to_rfc3339(),
         "version": "1.0.0",
-        "message": "API server is running"
+        "message": "API server with PostgreSQL"
     })))
 }
 
-/// Simple detailed health check - mock version
-async fn simple_detailed_health() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "status": "healthy",
-        "service": "API Mock Server",
-        "version": "1.0.0",
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-        "database": {
-            "status": "mocked",
-            "message": "No real database connected - using mock responses",
-            "postgresql_available": false,
-            "connection_string": "NOT_CONFIGURED",
-            "response_time_ms": null
-        },
-        "system": {
-            "hostname": "localhost",
-            "os": std::env::consts::OS,
-            "arch": std::env::consts::ARCH,
-            "pid": std::process::id(),
-            "cpu_cores": num_cpus::get()
-        },
-        "metrics": {
-            "uptime_seconds": 3600,
-            "total_requests": 42,
-            "active_connections": 1,
-            "avg_response_time_ms": 45.2,
-            "error_rate_percent": 0.1
-        }
-    })))
-}
+/// Configure real routes
+fn configure_real_routes(cfg: &mut web::ServiceConfig) {
+    cfg
+        // Health with a database
+        .service(
+            web::scope("/simple-health")
+                .route("", web::get().to(simple_health_with_db))
+                .route("/db-only", web::get().to(database_test_only)),
+        )
+        .route("/health", web::get().to(health_check));
 
-/// Readiness probe
-async fn readiness_probe() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "ready": true,
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-        "checks": {
-            "server": "healthy",
-            "database": "mocked",
-            "memory": "normal",
-            "disk": "sufficient"
-        }
-    })))
-}
-
-/// Liveness probe
-async fn liveness_probe() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "alive": true,
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-        "pid": std::process::id(),
-        "uptime": 3600
-    })))
-}
-
-/// Mock protected route handler - simulates authenticated endpoints
-async fn mock_protected() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "message": "Protected route accessed successfully",
-        "user_id": "mock-user-123",
-        "authenticated": true
-    })))
-}
-
-/// List users endpoint - returns paginated user collection
-async fn mock_users() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "users": [
-            {
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "username": "testuser",
-                "email": "test@example.com",
-                "status": "active"
-            }
-        ],
-        "total": 1,
-        "limit": 50,
-        "offset": 0
-    })))
-}
-
-/// Get user by ID endpoint - returns detailed user information
-async fn mock_user_by_id(path: web::Path<String>) -> Result<HttpResponse> {
-    let user_id = path.into_inner();
-    Ok(HttpResponse::Ok().json(json!({
-        "id": user_id,
-        "username": "testuser",
-        "email": "test@example.com",
-        "firstname": "Test",
-        "lastname": "User",
-        "display_name": "Test User",
-        "status": "active",
-        "email_verified": true,
-        "mfa_enabled": false,
-        "created_at": chrono::Utc::now().to_rfc3339(),
-        "updated_at": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Change user password endpoint - validates and updates user credentials
-async fn mock_change_password(
-    path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> Result<HttpResponse> {
-    let user_id = path.into_inner();
-    let current_password = payload.get("current_password").and_then(|v| v.as_str());
-    let new_password = payload.get("new_password").and_then(|v| v.as_str());
-
-    // Input validation
-    if current_password.is_none() || new_password.is_none() {
-        return Ok(HttpResponse::BadRequest().json(json!({
-            "error": "Validation failed",
-            "message": "Both current_password and new_password are required"
-        })));
-    }
-
-    // Password strength validation (mock)
-    if let Some(pwd) = new_password {
-        if pwd.len() < 8 {
-            return Ok(HttpResponse::BadRequest().json(json!({
-                "error": "Validation failed",
-                "message": "The new password must be at least 8 characters long"
-            })));
-        }
-    }
-
-    Ok(HttpResponse::Ok().json(json!({
-        "message": "Password changed successfully",
-        "user_id": user_id,
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Update user profile endpoint - modifies user personal information
-async fn mock_update_profile(
-    path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> Result<HttpResponse> {
-    let user_id = path.into_inner();
-
-    Ok(HttpResponse::Ok().json(json!({
-        "message": "Profile updated successfully",
-        "user_id": user_id,
-        "updated_fields": payload.into_inner(),
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Update user status endpoint - admin-only user account management
-async fn mock_update_status(
-    path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> Result<HttpResponse> {
-    let user_id = path.into_inner();
-    let status = payload.get("status").and_then(|v| v.as_str()).unwrap_or("active");
-
-    Ok(HttpResponse::Ok().json(json!({
-        "message": "User status updated successfully",
-        "user_id": user_id,
-        "new_status": status,
-        "updated_by": "admin",
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Assign role endpoint - admin-only role management
-async fn mock_assign_role(
-    path: web::Path<String>,
-    payload: web::Json<serde_json::Value>,
-) -> Result<HttpResponse> {
-    let user_id = path.into_inner();
-    let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("user");
-
-    Ok(HttpResponse::Ok().json(json!({
-        "message": "Role assigned successfully",
-        "user_id": user_id,
-        "role": role,
-        "assigned_by": "admin",
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Get user roles endpoint - returns user permission set
-async fn mock_get_user_roles(path: web::Path<String>) -> Result<HttpResponse> {
-    let user_id = path.into_inner();
-
-    Ok(HttpResponse::Ok().json(json!({
-        "user_id": user_id,
-        "roles": ["user", "customer"],
-        "permissions": ["read_profile", "update_profile", "create_orders"]
-    })))
-}
-
-/// User statistics endpoint - admin-only analytics data
-async fn mock_user_stats() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "total_users": 1547,
-        "active_users": 1289,
-        "pending_users": 156,
-        "suspended_users": 102,
-        "verified_emails": 1203,
-        "mfa_enabled": 687,
-        "recent_logins": 845,
-        "generated_at": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Find a user by email endpoint - admin-only user lookup
-async fn mock_user_by_email(query: web::Query<serde_json::Value>) -> Result<HttpResponse> {
-    let email = query.get("email").and_then(|v| v.as_str()).unwrap_or("unknown");
-
-    if email == "unknown" {
-        return Ok(HttpResponse::BadRequest().json(json!({
-            "error": "Missing parameter",
-            "message": "Email parameter is required"
-        })));
-    }
-
-    Ok(HttpResponse::Ok().json(json!({
-        "id": "550e8400-e29b-41d4-a716-446655440000",
-        "username": "testuser",
-        "email": email,
-        "firstname": "Test",
-        "lastname": "User",
-        "status": "active",
-        "found_by": "email"
-    })))
-}
-
-/// Find user by username endpoint - admin-only user lookup
-async fn mock_user_by_username(query: web::Query<serde_json::Value>) -> Result<HttpResponse> {
-    let username = query.get("username").and_then(|v| v.as_str()).unwrap_or("unknown");
-
-    if username == "unknown" {
-        return Ok(HttpResponse::BadRequest().json(json!({
-            "error": "Missing parameter",
-            "message": "Username parameter is required"
-        })));
-    }
-
-    Ok(HttpResponse::Ok().json(json!({
-        "id": "550e8400-e29b-41d4-a716-446655440000",
-        "username": username,
-        "email": "test@example.com",
-        "firstname": "Test",
-        "lastname": "User",
-        "status": "active",
-        "found_by": "username"
-    })))
-}
-
-/// User authentication endpoint - validates credentials and returns JWT tokens
-async fn mock_login(payload: web::Json<serde_json::Value>) -> Result<HttpResponse> {
-    let email = payload.get("email").and_then(|v| v.as_str());
-    let password = payload.get("password").and_then(|v| v.as_str());
-
-    // Basic validation
-    if email.is_none() || password.is_none() {
-        return Ok(HttpResponse::BadRequest().json(json!({
-            "error": "Invalid credentials",
-            "message": "Email and password are required"
-        })));
-    }
-
-    Ok(HttpResponse::Ok().json(json!({
-        "access_token": "mock_access_token_12345",
-        "refresh_token": "mock_refresh_token_67890",
-        "token_type": "Bearer",
-        "expires_in": 3600,
-        "user": {
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "email": email.unwrap(),
-            "username": "testuser"
-        },
-        "login_timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// User registration endpoint - creates a new user account
-async fn mock_register(payload: web::Json<serde_json::Value>) -> Result<HttpResponse> {
-    let email = payload.get("email").and_then(|v| v.as_str());
-    let username = payload.get("username").and_then(|v| v.as_str());
-    let password = payload.get("password").and_then(|v| v.as_str());
-
-    // Validation
-    if email.is_none() || username.is_none() || password.is_none() {
-        return Ok(HttpResponse::BadRequest().json(json!({
-            "error": "Validation failed",
-            "message": "Email, username, and password are required"
-        })));
-    }
-
-    Ok(HttpResponse::Created().json(json!({
-        "user_id": "550e8400-e29b-41d4-a716-446655440000",
-        "email": email.unwrap(),
-        "username": username.unwrap(),
-        "message": "User registered successfully",
-        "status": "pending_verification",
-        "created_at": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Mock database connection test - simulates real DB connectivity
-async fn mock_db_test() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "database_status": "mocked",
-        "connection": "simulated",
-        "test_query": "SELECT 1",
-        "result": "success (mock)",
-        "message": "This is a mock response. Real database would return actual connection status.",
-        "postgresql_available": false,
-        "mock_mode": true,
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Mock database tables info - simulates table listing
-async fn mock_db_tables() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(json!({
-        "tables": [
-            {
-                "name": "users",
-                "rows": 1547,
-                "size": "2.3MB"
-            },
-            {
-                "name": "sessions",
-                "rows": 234,
-                "size": "0.8MB"
-            },
-            {
-                "name": "roles",
-                "rows": 12,
-                "size": "0.1MB"
-            }
-        ],
-        "total_tables": 3,
-        "database_size": "3.2MB",
-        "status": "mocked",
-        "message": "Mock table information. A real database would show actual tables.",
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-/// Configure all API routes and middleware
-fn configure_routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(
-        web::scope("/simple-health")
-            .route("", web::get().to(simple_health_with_db))
-            .route("/db-only", web::get().to(database_test_only)),
-    )
-    // ⭐ HEALTH ROUTES
-    .route("/api/v1/health", web::get().to(health_check))
-    .route("/health", web::get().to(health_check))
-    .route("/health/detailed", web::get().to(simple_detailed_health))
-    .route("/health/ready", web::get().to(readiness_probe))
-    .route("/health/live", web::get().to(liveness_probe))
-    // Authentication routes
-    .service(
-        web::scope("/api/v1/auth")
-            .route("/login", web::post().to(mock_login))
-            .route("/register", web::post().to(mock_register)),
-    )
-    // Protected routes (require authentication)
-    .service(
-        web::scope("/api/v1/protected")
-            .route("", web::get().to(mock_protected))
-            .route("/profile", web::get().to(mock_protected))
-            .route("/settings", web::put().to(mock_protected))
-            .route("/orders", web::get().to(mock_protected))
-            .route("/logout", web::post().to(mock_protected)),
-    )
-    // User management routes
-    .service(
-        web::scope("/api/v1/users")
-            // User collection operations
-            .route("", web::get().to(mock_users))
-            .route("/stats", web::get().to(mock_user_stats))
-            .route("/by-email", web::get().to(mock_user_by_email))
-            .route("/by-username", web::get().to(mock_user_by_username))
-            // Individual user operations
-            .route("/{id}", web::get().to(mock_user_by_id))
-            .route("/{id}/profile", web::put().to(mock_update_profile))
-            .route("/{id}/password", web::put().to(mock_change_password))
-            .route("/{id}/status", web::put().to(mock_update_status))
-            .route("/{id}/roles", web::post().to(mock_assign_role))
-            .route("/{id}/roles", web::get().to(mock_get_user_roles)),
-    )
-    // ⭐ DEBUG ROUTES - Pour tester la connexion BDD
-    .service(
-        web::scope("/api/v1/debug")
-            .route("/db-test", web::get().to(mock_db_test))
-            .route("/db-tables", web::get().to(mock_db_tables)),
-    );
+    // TODO: Add real auth/user routes here when ready
+    // .configure(configure_auth_routes)
+    // .configure(configure_user_routes)
 }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenvy::dotenv().ok();
-    // Initialize logging
     env_logger::init();
 
-    // Server startup information
-    println!("🚀 API Mock Server started on http://localhost:3000");
-    println!("\n📋 Available endpoints:");
-    println!("┌─ Health & System");
-    println!("│  GET  /api/v1/health");
-    println!("│  GET  /health           ⭐ WORKING!");
-    println!("│  GET  /health/detailed  ⭐ WORKING!");
-    println!("│  GET  /health/ready     ⭐ WORKING!");
-    println!("│  GET  /health/live      ⭐ WORKING!");
-    println!("├─ Authentication");
-    println!("│  POST /api/v1/auth/login");
-    println!("│  POST /api/v1/auth/register");
-    println!("├─ Protected Routes");
-    println!("│  GET  /api/v1/protected");
-    println!("│  GET  /api/v1/protected/profile");
-    println!("│  PUT  /api/v1/protected/settings");
-    println!("│  GET  /api/v1/protected/orders");
-    println!("│  POST /api/v1/protected/logout");
-    println!("├─ User Management");
-    println!("│  GET  /api/v1/users");
-    println!("│  GET  /api/v1/users/{{id}}");
-    println!("│  PUT  /api/v1/users/{{id}}/profile");
-    println!("│  PUT  /api/v1/users/{{id}}/password  ⭐ TARGET!");
-    println!("│  PUT  /api/v1/users/{{id}}/status");
-    println!("│  POST /api/v1/users/{{id}}/roles");
-    println!("│  GET  /api/v1/users/{{id}}/roles");
-    println!("│  GET  /api/v1/users/stats");
-    println!("│  GET  /api/v1/users/by-email");
-    println!("│  GET  /api/v1/users/by-username");
-    println!("└─ Database Debug");
-    println!("   GET  /api/v1/debug/db-test    ⭐ NEW!");
-    println!("   GET  /api/v1/debug/db-tables  ⭐ NEW!");
-    println!("\n💡 All endpoints are mocked for testing purposes");
-    println!("🗄️ Database: MOCKED - No real PostgreSQL connection");
-    println!("🔧 Use debug endpoints to simulate DB connectivity checks");
+    println!("Server started on http://localhost:3000");
+    println!("Mode: PRODUCTION with PostgreSQL");
+    println!(" Database: Uses your migration schema");
+    println!("\n✅ Currently available endpoints:");
+    println!("GET/simple-health/db-only ← TEST DB.");
+    println!("GET/simple-health ← FULL DB STATUS.");
+    println!("GET/health ← BASIC HEALTH!");
+    println!("\n Coming soon:");
+    println!("POST /api/v1/auth/register ← When auth module ready");
+    println!("PUT  /api/v1/users/{{id}}/password ← When user module ready");
 
-    // Start HTTP server
-    HttpServer::new(|| App::new().configure(configure_routes)).bind("127.0.0.1:3000")?.run().await
+    HttpServer::new(|| App::new().configure(configure_real_routes))
+        .bind("127.0.0.1:3000")?
+        .run()
+        .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 //! Production-ready mock implementation without complex dependencies
 
 mod simple_health;
+mod sqlx;
 
 use crate::simple_health::{database_test_only, simple_health_with_db};
 use actix_web::{web, App, HttpResponse, HttpServer, Result};

--- a/src/mock_handlers.rs
+++ b/src/mock_handlers.rs
@@ -1,0 +1,94 @@
+//! Shared mock handlers
+use actix_web::{web, HttpResponse};
+use serde_json::{json, Value};
+
+/// Health check endpoint
+pub async fn health_check() -> HttpResponse {
+    HttpResponse::Ok().json(json!({
+        "status": "healthy",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "version": "1.0.0",
+        "message": "Mock API server"
+    }))
+}
+
+/// Mock login endpoint
+pub async fn mock_login(payload: web::Json<Value>) -> HttpResponse {
+    let email = payload.get("email").and_then(|v| v.as_str());
+    let password = payload.get("password").and_then(|v| v.as_str());
+
+    if email.is_none() || password.is_none() {
+        return HttpResponse::BadRequest().json(json!({
+            "error": "Invalid credentials",
+            "message": "Email and password are required"
+        }));
+    }
+
+    HttpResponse::Ok().json(json!({
+        "access_token": "mock_access_token_12345",
+        "refresh_token": "mock_refresh_token_67890",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "user": {
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "email": email.unwrap(),
+            "username": "testuser"
+        },
+        "login_timestamp": chrono::Utc::now().to_rfc3339()
+    }))
+}
+
+/// Mock register endpoint
+pub async fn mock_register(payload: web::Json<Value>) -> HttpResponse {
+    let email = payload.get("email").and_then(|v| v.as_str());
+    let username = payload.get("username").and_then(|v| v.as_str());
+    let password = payload.get("password").and_then(|v| v.as_str());
+
+    if email.is_none() || username.is_none() || password.is_none() {
+        return HttpResponse::BadRequest().json(json!({
+            "error": "Validation failed",
+            "message": "Email, username, and password are required"
+        }));
+    }
+
+    HttpResponse::Created().json(json!({
+        "user_id": "550e8400-e29b-41d4-a716-446655440000",
+        "email": email.unwrap(),
+        "username": username.unwrap(),
+        "message": "User registered successfully",
+        "status": "pending_verification",
+        "created_at": chrono::Utc::now().to_rfc3339()
+    }))
+}
+
+/// Mock change password endpoint
+pub async fn mock_change_password(
+    path: web::Path<String>,
+    payload: web::Json<Value>,
+) -> HttpResponse {
+    let user_id = path.into_inner();
+    let current_password = payload.get("current_password").and_then(|v| v.as_str());
+    let new_password = payload.get("new_password").and_then(|v| v.as_str());
+
+    if current_password.is_none() || new_password.is_none() {
+        return HttpResponse::BadRequest().json(json!({
+            "error": "Validation failed",
+            "message": "Both current_password and new_password are required"
+        }));
+    }
+
+    if let Some(pwd) = new_password {
+        if pwd.len() < 8 {
+            return HttpResponse::BadRequest().json(json!({
+                "error": "Validation failed",
+                "message": "The new password must be at least 8 characters long"
+            }));
+        }
+    }
+
+    HttpResponse::Ok().json(json!({
+        "message": "Password changed successfully",
+        "user_id": user_id,
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    }))
+}

--- a/src/mocks/mock_handlers.rs
+++ b/src/mocks/mock_handlers.rs
@@ -1,0 +1,373 @@
+//! Mock handlers pour les tests et le développement
+//! Sépare complètement les mocks du serveur principal
+
+use actix_web::{web, HttpResponse, Result};
+use serde_json::json;
+
+/// Mock protected route handler - simulates authenticated endpoints
+pub async fn mock_protected() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Protected route accessed successfully",
+        "user_id": "mock-user-123",
+        "authenticated": true
+    })))
+}
+
+/// List users endpoint - returns paginated user collection
+pub async fn mock_users() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "users": [
+            {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "username": "testuser",
+                "email": "test@example.com",
+                "status": "active"
+            }
+        ],
+        "total": 1,
+        "limit": 50,
+        "offset": 0
+    })))
+}
+
+/// Get user by ID endpoint - returns detailed user information
+pub async fn mock_user_by_id(path: web::Path<String>) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    Ok(HttpResponse::Ok().json(json!({
+        "id": user_id,
+        "username": "testuser",
+        "email": "test@example.com",
+        "firstname": "Test",
+        "lastname": "User",
+        "display_name": "Test User",
+        "status": "active",
+        "email_verified": true,
+        "mfa_enabled": false,
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "updated_at": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// User authentication endpoint - validates credentials and returns JWT tokens
+pub async fn mock_login(payload: web::Json<serde_json::Value>) -> Result<HttpResponse> {
+    let email = payload.get("email").and_then(|v| v.as_str());
+    let password = payload.get("password").and_then(|v| v.as_str());
+
+    // Basic validation
+    if email.is_none() || password.is_none() {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Invalid credentials",
+            "message": "Email and password are required"
+        })));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "access_token": "mock_access_token_12345",
+        "refresh_token": "mock_refresh_token_67890",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "user": {
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "email": email.unwrap(),
+            "username": "testuser"
+        },
+        "login_timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// User registration endpoint - creates a new user account
+pub async fn mock_register(payload: web::Json<serde_json::Value>) -> Result<HttpResponse> {
+    let email = payload.get("email").and_then(|v| v.as_str());
+    let username = payload.get("username").and_then(|v| v.as_str());
+    let password = payload.get("password").and_then(|v| v.as_str());
+
+    // Validation
+    if email.is_none() || username.is_none() || password.is_none() {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Validation failed",
+            "message": "Email, username, and password are required"
+        })));
+    }
+
+    Ok(HttpResponse::Created().json(json!({
+        "user_id": "550e8400-e29b-41d4-a716-446655440000",
+        "email": email.unwrap(),
+        "username": username.unwrap(),
+        "message": "User registered successfully",
+        "status": "pending_verification",
+        "created_at": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Change user password endpoint - validates and updates user credentials
+pub async fn mock_change_password(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let current_password = payload.get("current_password").and_then(|v| v.as_str());
+    let new_password = payload.get("new_password").and_then(|v| v.as_str());
+
+    // Input validation
+    if current_password.is_none() || new_password.is_none() {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Validation failed",
+            "message": "Both current_password and new_password are required"
+        })));
+    }
+
+    // Password strength validation (mock)
+    if let Some(pwd) = new_password {
+        if pwd.len() < 8 {
+            return Ok(HttpResponse::BadRequest().json(json!({
+                "error": "Validation failed",
+                "message": "The new password must be at least 8 characters long"
+            })));
+        }
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Password changed successfully",
+        "user_id": user_id,
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Mock database connection test - simulates real DB connectivity
+pub async fn mock_db_test() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "database_status": "mocked",
+        "connection": "simulated",
+        "test_query": "SELECT 1",
+        "result": "success (mock)",
+        "message": "This is a mock response. Real database would return actual connection status.",
+        "postgresql_available": false,
+        "mock_mode": true,
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Health check endpoint - returns server status and metadata
+pub async fn health_check() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "healthy",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "version": "1.0.0",
+        "message": "API server is running"
+    })))
+}
+
+/// Simple detailed health check - mock version
+pub async fn simple_detailed_health() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "healthy",
+        "service": "API Mock Server",
+        "version": "1.0.0",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "database": {
+            "status": "mocked",
+            "message": "No real database connected - using mock responses",
+            "postgresql_available": false,
+            "connection_string": "NOT_CONFIGURED",
+            "response_time_ms": null
+        },
+        "system": {
+            "hostname": "localhost",
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "pid": std::process::id(),
+            "cpu_cores": num_cpus::get()
+        },
+        "metrics": {
+            "uptime_seconds": 3600,
+            "total_requests": 42,
+            "active_connections": 1,
+            "avg_response_time_ms": 45.2,
+            "error_rate_percent": 0.1
+        }
+    })))
+}
+
+/// Readiness probe
+pub async fn readiness_probe() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "ready": true,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "checks": {
+            "server": "healthy",
+            "database": "mocked",
+            "memory": "normal",
+            "disk": "sufficient"
+        }
+    })))
+}
+
+/// Liveness probe
+pub async fn liveness_probe() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "alive": true,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "pid": std::process::id(),
+        "uptime": 3600
+    })))
+}
+
+/// Update user profile endpoint - modifies user personal information
+async fn mock_update_profile(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Profile updated successfully",
+        "user_id": user_id,
+        "updated_fields": payload.into_inner(),
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Update user status endpoint - admin-only user account management
+async fn mock_update_status(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let status = payload.get("status").and_then(|v| v.as_str()).unwrap_or("active");
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "User status updated successfully",
+        "user_id": user_id,
+        "new_status": status,
+        "updated_by": "admin",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Assign role endpoint - admin-only role management
+async fn mock_assign_role(
+    path: web::Path<String>,
+    payload: web::Json<serde_json::Value>,
+) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+    let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+
+    Ok(HttpResponse::Ok().json(json!({
+        "message": "Role assigned successfully",
+        "user_id": user_id,
+        "role": role,
+        "assigned_by": "admin",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Get user roles endpoint - returns user permission set
+async fn mock_get_user_roles(path: web::Path<String>) -> Result<HttpResponse> {
+    let user_id = path.into_inner();
+
+    Ok(HttpResponse::Ok().json(json!({
+        "user_id": user_id,
+        "roles": ["user", "customer"],
+        "permissions": ["read_profile", "update_profile", "create_orders"]
+    })))
+}
+
+/// User statistics endpoint - admin-only analytics data
+async fn mock_user_stats() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "total_users": 1547,
+        "active_users": 1289,
+        "pending_users": 156,
+        "suspended_users": 102,
+        "verified_emails": 1203,
+        "mfa_enabled": 687,
+        "recent_logins": 845,
+        "generated_at": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Find a user by email endpoint - admin-only user lookup
+async fn mock_user_by_email(query: web::Query<serde_json::Value>) -> Result<HttpResponse> {
+    let email = query.get("email").and_then(|v| v.as_str()).unwrap_or("unknown");
+
+    if email == "unknown" {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Missing parameter",
+            "message": "Email parameter is required"
+        })));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "username": "testuser",
+        "email": email,
+        "firstname": "Test",
+        "lastname": "User",
+        "status": "active",
+        "found_by": "email"
+    })))
+}
+
+/// Find user by username endpoint - admin-only user lookup
+async fn mock_user_by_username(query: web::Query<serde_json::Value>) -> Result<HttpResponse> {
+    let username = query.get("username").and_then(|v| v.as_str()).unwrap_or("unknown");
+
+    if username == "unknown" {
+        return Ok(HttpResponse::BadRequest().json(json!({
+            "error": "Missing parameter",
+            "message": "Username parameter is required"
+        })));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "username": username,
+        "email": "test@example.com",
+        "firstname": "Test",
+        "lastname": "User",
+        "status": "active",
+        "found_by": "username"
+    })))
+}
+
+/// Mock database connection test - simulates real DB connectivity
+async fn mock_db_test() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "database_status": "mocked",
+        "connection": "simulated",
+        "test_query": "SELECT 1",
+        "result": "success (mock)",
+        "message": "This is a mock response. Real database would return actual connection status.",
+        "postgresql_available": false,
+        "mock_mode": true,
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}
+
+/// Mock database tables info - simulates table listing
+async fn mock_db_tables() -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(json!({
+        "tables": [
+            {
+                "name": "users",
+                "rows": 1547,
+                "size": "2.3MB"
+            },
+            {
+                "name": "sessions",
+                "rows": 234,
+                "size": "0.8MB"
+            },
+            {
+                "name": "roles",
+                "rows": 12,
+                "size": "0.1MB"
+            }
+        ],
+        "total_tables": 3,
+        "database_size": "3.2MB",
+        "status": "mocked",
+        "message": "Mock table information. A real database would show actual tables.",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}

--- a/src/mocks/mod.rs
+++ b/src/mocks/mod.rs
@@ -1,2 +1,2 @@
 pub mod mock_client;
-mod mock_oauth;
+pub mod mock_oauth;

--- a/src/simple_health.rs
+++ b/src/simple_health.rs
@@ -144,7 +144,7 @@ pub async fn database_test_only() -> Result<HttpResponse> {
 
     println!("🔍 Testing database connection: {}", db_connection.replace(":password@", ":***@"));
 
-    let db_status = if db_connection.starts_with("postgresql://") {
+    let db_status = if db_connection.starts_with("postgresql") {
         test_postgresql_connection(&db_connection).await
     } else {
         test_mock_database().await


### PR DESCRIPTION
## Résumé par Sourcery

Migrer la base de code d'une API entièrement simulée vers un serveur réel basé sur Postgres tout en préservant les serveurs de simulation autonomes ; refactoriser les simulations client vers sqlx, nettoyer les routes héritées et mettre à jour la documentation et la configuration de build.

Nouvelles Fonctionnalités :
- Intégrer PostgreSQL dans le serveur HTTP principal avec de véritables points d'accès de santé et de test de base de données
- Ajouter des binaires séparés pour le serveur réel (`main`), le serveur de simulation complet (`mock_server`) et le serveur de simulation simple (`simple_mock`)

Corrections de Bugs :
- Corriger la vérification du préfixe de la chaîne de connexion à la base de données dans `simple_health` pour reconnaître les URI `postgresql`

Améliorations :
- Refactoriser MockClient pour utiliser les types sqlx au lieu des interfaces tokio_postgres
- Restructurer le projet en une bibliothèque (`src/lib.rs`) avec des gestionnaires de simulation partagés et une disposition de module simplifiée
- Réexporter les éléments courants comme `MfaType` et simplifier les importations de modules

Compilation :
- Définir plusieurs binaires dans Cargo.toml pour les serveurs réels et de simulation

Documentation :
- Traduire et mettre à jour ROUTES.md en anglais et ajouter des exemples de requêtes HTTP

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the codebase from a fully mocked API to a real Postgres-backed server while preserving standalone mock servers; refactor client mocks to sqlx, clean up legacy routes, and update documentation and build configuration.

New Features:
- Integrate PostgreSQL into the main HTTP server with real health and database test endpoints
- Add separate binaries for real server (`main`), full mock server (`mock_server`), and simple mock server (`simple_mock`)

Bug Fixes:
- Fix database connection string prefix check in `simple_health` to recognize `postgresql` URIs

Enhancements:
- Refactor MockClient to use sqlx types instead of tokio_postgres interfaces
- Restructure project into a library (`src/lib.rs`) with shared mock handlers and simplified module layout
- Re-export common items like `MfaType` and simplify module imports

Build:
- Define multiple binaries in Cargo.toml for real and mock servers

Documentation:
- Translate and update ROUTES.md to English and add HTTP request examples

</details>